### PR TITLE
Add manual workflow

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,52 @@
+name: Manually Build and Push Image on ECR
+
+on: workflow_dispatch
+
+env:
+  AWS_REGION: eu-west-1
+  ECR_REPOSITORY: highs
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    name: Build HiGHS Docker Image
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        
+      - name: Zip Release
+        uses: TheDoctor0/zip-release@0.6.2
+        with:
+          filename: HiGHS.zip
+          
+    ##Useful to download the content of the zip
+      #- name: my-artifact 
+      #  uses: actions/upload-artifact@v3.0.0
+      #  with:
+      #    path: ${{ github.workspace }}/HiGHS.zip
+      
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+        
+      

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin:17-alpine
 RUN apk update && \
         apk upgrade && \
         apk add --no-cache \
-            cmake=3.21.3-r0 \
+            cmake>3.21.3-r0 \
             make \
             g++ \
             gcc \


### PR DESCRIPTION
# Add
- Github workflow to manually (i.e. withhout push/merge) run the build&push action
# Fix
- `cmake` version now is defined with a lower limit, because the base image (`eclipse-temurin:17-alpine`) has updated the alpine base version, making invalid the previous version